### PR TITLE
Prepare for Moodle 4.5

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.0', '8.1', '8.2', '8.3']
-        moodle-branch: ['MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE', 'MOODLE_404_STABLE', 'main']
+        moodle-branch: ['MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE', 'MOODLE_404_STABLE', 'MOODLE_405_STABLE', 'main']
         database: [mariadb, pgsql]
         exclude:
           - moodle-branch: 'MOODLE_401_STABLE'
@@ -43,6 +43,8 @@ jobs:
           - moodle-branch: 'MOODLE_403_STABLE'
             php: '8.3'
           - moodle-branch: 'MOODLE_404_STABLE'
+            php: '8.0'
+          - moodle-branch: 'MOODLE_405_STABLE'
             php: '8.0'
           - moodle-branch: 'main'
             php: '8.0'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 1.2.0 (2024-10-07)
+
+- assure compatibility with freshly released Moodle 4.5 LTS
+- improvement: add possibility to export formatted responses to PDF
+- internal: added tests
+- internal: remove temporary CI change after bug in moodle-plugin-ci was fixed
+
 ### 1.1.0 (2024-08-23)
 
 - improvement: add setting to choose between ordering by first/last or last/first name

--- a/version.php
+++ b/version.php
@@ -25,9 +25,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024082300;
+$plugin->version   = 2024100700;
 $plugin->requires  = 2022112800;
 $plugin->component = 'quiz_essaydownload';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.1.0';
+$plugin->release   = '1.2.0';
 


### PR DESCRIPTION
Moodle 4.5 LTS will be released on October 7th. Make sure we are ready and fully compatible by then, releasing our version 1.2.0 with new functionality.